### PR TITLE
Add ability to initialize controller with custom projectId

### DIFF
--- a/src/cli/commands/start.js
+++ b/src/cli/commands/start.js
@@ -47,7 +47,8 @@ exports.options = [
   'supervisorPort',
   'timeout',
   'useMocks',
-  'verbose'
+  'verbose',
+  'projectId'
 ];
 
 /**

--- a/src/cli/controller.js
+++ b/src/cli/controller.js
@@ -613,7 +613,8 @@ class Controller {
           `--restHost=${this.config.restHost}`,
           `--restPort=${this.config.restPort}`,
           `--supervisorHost=${this.config.supervisorHost}`,
-          `--supervisorPort=${this.config.supervisorPort}`
+          `--supervisorPort=${this.config.supervisorPort}`,
+          `--projectId=${this.config.projectId}`
         ];
 
         // Make sure the child is detached, otherwise it will be bound to the


### PR DESCRIPTION
CLI Controller can now be initialized with a project ID, example:
var controller = new EmulatorController({projectId: 'your-firebase-project-id'});