### PR TITLE
Migrate `{rest,grpc,supervisor}Host` to `host`

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,10 +23,12 @@ const pkg = require('../package.json');
 
 const config = module.exports = new Configstore(path.join(pkg.name, '/config'), defaults);
 
-// Config migration
-if (config.get('restHost') || config.get('grpcHost') || config.get('supervisorHost')) {
-  config.set('host', config.get('restHost') || config.get('grpcHost') || config.get('supervisorHost'));
-  config.delete('restHost');
-  config.delete('grpcHost');
-  config.delete('supervisorHost');
-}
+// migrate legacy {rest,grpc,supervisor}Host to host
+const host = ['grpcHost', 'supervisorHost'].reduce((host, key) => {
+  return host !== 'localhost' ? host : config.get(key);
+}, config.get('restHost'));
+
+config.set('host', host);
+config.delete('restHost');
+config.delete('grpcHost');
+config.delete('supervisorHost');


### PR DESCRIPTION
Like it says on the tin. If any of `restHost`, `grpcHost` or `supervisorHost` have a value other than `localhost`, that value is used as the initial value for `host`. Precedence is in the order listed.

- [x] - `npm test` succeeds
- [x] - Code coverage does not decrease (if any source code was changed)
- [x] - If applicable, PR includes appropriate documentation changes
