### PR TITLE
Prevent emulator from hanging from requiring user code that doesn't exit.

### DIFF
--- a/src/cli/controller.js
+++ b/src/cli/controller.js
@@ -127,7 +127,7 @@ class Controller {
 
     return new Promise((resolve, reject) => {
       // Parse the user's code to find the names of the exported functions
-      exec(`node -e "console.log(Object.keys(require('${pathForCmd}') || {}))"`, (err, stdout, stderr) => {
+      exec(`node -e "console.log(Object.keys(require('${pathForCmd}') || {})); setTimeout(function() { process.exit(0); }, 100);"`, (err, stdout, stderr) => {
         if (err) {
           this.error(`${'ERROR'.red}: Function load error: Code could not be loaded.`);
           this.error(`${'ERROR'.red}: Does the file exists? Is there a syntax error in your code?`);


### PR DESCRIPTION
This fixes the bug where the emulator hangs when there's something within the functions source code that causes the process to not exit. For example, if someone has the following lines at a global scope (outside of exported functions):
```
var firebase = require('firebase-admin')
firebase.initializeApp(...);
var databaseRef = firebase.database(); // this opens up a connection to the database, which forces the process to not exit.
```

The set timeout is there since otherwise there may an issue with console.log not displaying the full output due to not having enough time to clear the buffer.