### PR TITLE
Update supported Node.js version to 6.11.1

### DIFF
--- a/bin/emulator
+++ b/bin/emulator
@@ -17,13 +17,13 @@
 
 const semver = require('semver');
 
-if (!semver.satisfies(process.version, '>= 6.9.1')) {
-  console.error('Node.js v6.9.x or greater is required to run the Emulator!');
+if (!semver.satisfies(process.version, '>= 6.11.1')) {
+  console.error('Node.js v6.11.x or greater is required to run the Emulator!');
   process.exit(1);
 }
 
 if (semver.satisfies(process.version, '>= 7.0.0')) {
-  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions only supports v6.9.1.`);
+  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions only supports v6.11.1.`);
 }
 
 exports.emulator = require('../src/emulator');

--- a/bin/functions
+++ b/bin/functions
@@ -21,13 +21,13 @@ require('colors');
  * 1. Verify the version of Node.js being used.
  */
 const semver = require('semver');
-if (!semver.satisfies(process.version, '>= 6.9.1')) {
-  console.error('Node.js v6.9.1 or greater is required to run the Emulator!');
+if (!semver.satisfies(process.version, '>= 6.11.1')) {
+  console.error('Node.js v6.11.1 or greater is required to run the Emulator!');
   process.exit(1);
 }
 
 if (semver.satisfies(process.version, '>= 7.0.0')) {
-  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions only supports v6.9.1.`);
+  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions only supports v6.11.1.`);
 }
 
 /**

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@
 # Adjust the behavior of the virtual machine (VM)
 machine:
   node:
-    version: 6.9.1
+    version: 6.11.1
 
 # Use for broader build-related configuration
 general:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=6.9.1"
+    "node": ">=6.11.1"
   },
   "main": "./bin/emulator",
   "bin": {


### PR DESCRIPTION
This PR updates the supported Node.js version to 6.11.1. The new runtime version will be used for all _deploys_ starting Monday, July 17th 2017.

cc @jmdobry @jasonpolites 

- [ ] - `npm test` succeeds
