### PR TITLE
Add limit to bodyParser middlewares

### DIFF
--- a/src/service/rest-service.js
+++ b/src/service/rest-service.js
@@ -45,11 +45,18 @@ class RestService extends Service {
     // Standard ExpressJS app. Where possible this should mimic the *actual*
     // setup of Cloud Functions regarding the use of body parsers etc.
     this.server = express();
-    this.server.use(bodyParser.json());
-    this.server.use(bodyParser.raw());
-    this.server.use(bodyParser.text());
+    this.server.use(bodyParser.json({
+      limit: '10mb'
+    }));
+    this.server.use(bodyParser.raw({
+      limit: '10mb'
+    }));
+    this.server.use(bodyParser.text({
+      limit: '10mb'
+    }));
     this.server.use(bodyParser.urlencoded({
-      extended: true
+      extended: true,
+      limit: '10mb'
     }));
 
     // Never cache

--- a/src/supervisor/supervisor.js
+++ b/src/supervisor/supervisor.js
@@ -67,11 +67,18 @@ class Supervisor {
 
     // Setup the Supervisor API
     const apiRouter = express.Router();
-    apiRouter.use(bodyParser.json());
-    apiRouter.use(bodyParser.raw());
-    apiRouter.use(bodyParser.text());
+    apiRouter.use(bodyParser.json({
+      limit: '10mb'
+    }));
+    apiRouter.use(bodyParser.raw({
+      limit: '10mb'
+    }));
+    apiRouter.use(bodyParser.text({
+      limit: '10mb'
+    }));
     apiRouter.use(bodyParser.urlencoded({
-      extended: true
+      extended: true,
+      limit: '10mb'
     }));
     apiRouter.post('/clear', (req, res, next) => this.clearHandler(req, res).catch(next));
     apiRouter.post('/debug', (req, res, next) => this.debugHandler(req, res).catch(next));

--- a/src/supervisor/worker.js
+++ b/src/supervisor/worker.js
@@ -71,11 +71,18 @@ function main () {
     const app = express();
 
     // Parse request body
-    app.use(bodyParser.json());
-    app.use(bodyParser.raw());
-    app.use(bodyParser.text());
+    app.use(bodyParser.json({
+      limit: '10mb'
+    }));
+    app.use(bodyParser.raw({
+      limit: '10mb'
+    }));
+    app.use(bodyParser.text({
+      limit: '10mb'
+    }));
     app.use(bodyParser.urlencoded({
-      extended: true
+      extended: true,
+      limit: '10mb'
     }));
 
     // Never cache


### PR DESCRIPTION
According to the documentation - https://cloud.google.com/functions/quotas
Request size is 10mb.

Google Cloud Functions emulator relies on bodyParser but does not use limit option and hence it defaults to default bodyParser limit of 100kb

This PR increases the limit to 10mb to match documented quotas.

Please let me know if any changes are required. 

Fixes https://github.com/GoogleCloudPlatform/cloud-functions-emulator/issues/136

- [x] - `npm test` succeeds (Was not straightforward though, ran into https://github.com/GoogleCloudPlatform/cloud-functions-emulator/issues/122)
- [x] - Code coverage does not decrease (if any source code was changed)
- [x] - If applicable, PR includes appropriate documentation changes
