### PR TITLE
setting the body parser limits to 10mb. default value is 100kbb

### DIFF
--- a/src/supervisor/worker.js
+++ b/src/supervisor/worker.js
@@ -71,10 +71,11 @@ function main () {
     const app = express();
 
     // Parse request body
-    app.use(bodyParser.json());
-    app.use(bodyParser.raw());
-    app.use(bodyParser.text());
+    app.use(bodyParser.json({limit: '10mb'}));
+    app.use(bodyParser.raw({limit: '10mb'}));
+    app.use(bodyParser.text({limit: '10mb'}));
     app.use(bodyParser.urlencoded({
+      limit: '10mb',
       extended: true
     }));
 

--- a/src/supervisor/worker.js
+++ b/src/supervisor/worker.js
@@ -69,15 +69,30 @@ function main () {
     }
 
     const app = express();
+    
+    const requestLimit = '1024mb';
+    
+    const rawBodySaver = (req, res, buf) => {
+      req.rawBody = buf;
+    };
+
+    const rawBodySavingOptions = {
+      limit: requestLimit,
+      verify: rawBodySaver
+    };
+
+    // Use extended query string parsing for URL-encoded bodies.
+    const urlEncodedOptions = {
+      limit: requestLimit,
+      verify: rawBodySaver,
+      extended: true
+    };
 
     // Parse request body
-    app.use(bodyParser.json({limit: '10mb'}));
-    app.use(bodyParser.raw({limit: '10mb'}));
-    app.use(bodyParser.text({limit: '10mb'}));
-    app.use(bodyParser.urlencoded({
-      limit: '10mb',
-      extended: true
-    }));
+    app.use(bodyParser.raw(rawBodySavingOptions));
+    app.use(bodyParser.json(rawBodySavingOptions));
+    app.use(bodyParser.text(rawBodySavingOptions));
+    app.use(bodyParser.urlencoded(urlEncodedOptions));
 
     // Never cache
     app.use((req, res, next) => {


### PR DESCRIPTION
reference: https://github.com/expressjs/body-parser#limit

Fixes #151 (it's a good idea to open an issue first for discussion)

- [x] - `npm test` succeeds
- [x] - Code coverage does not decrease (if any source code was changed)
- [ ] - If applicable, PR includes appropriate documentation changes
