### PR TITLE
Fix #162

### DIFF
--- a/src/supervisor/supervisor.js
+++ b/src/supervisor/supervisor.js
@@ -33,7 +33,7 @@ const server = require('../server');
 
 const DEFAULT_MAX_IDLE = 5 * 60 * 1000;
 const DEFAULT_IDLE_PRUNE_INTERVAL = 60 * 1000;
-const NAME_REG_EXP = /^\/([-\w]+)\/([-\w]+)\/([A-Za-z][-A-Za-z0-9]*)/;
+const NAME_REG_EXP = /^\/([-\w]+)\/([-\w]+)\/([A-Za-z][-A-Za-z0-9_]*)/;
 
 const { CloudFunction } = Model;
 


### PR DESCRIPTION
- Fix #162
  - there was an unfixed `NAME_REG_EXP` in `src/supervisor/supervisor.js`

## See also:
- https://github.com/GoogleCloudPlatform/cloud-functions-emulator/issues/159
- https://github.com/GoogleCloudPlatform/cloud-functions-emulator/commit/781f45eac8300c8c99938cad30a4673b101d5ff4