### PR TITLE
changed getter for supervisorHost to allow for bindHost option

### DIFF
--- a/src/model/functions.js
+++ b/src/model/functions.js
@@ -612,7 +612,7 @@ class Functions {
   }
 
   getSupervisorHost () {
-    return `http://localhost:${this.config.supervisorPort}`;
+    return `http://${this.config.bindHost}:${this.config.supervisorPort}`;
   }
 
   /**


### PR DESCRIPTION
Fixes #346 (in conjunction with a fix in the firebase repository)

The getter for the supervisor host always returned localhost as the ip address. This causes an issue when `bindHost` is set to a specific ip address since the supervisor will be started on that ip address, but the emulator will continue to try and connect to the supervisor on localhost. 

- [ ] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
