### PR TITLE
make node version error message clearer to enable easy debugging

### DIFF
--- a/bin/emulator
+++ b/bin/emulator
@@ -18,7 +18,7 @@
 const semver = require('semver');
 
 if (!semver.satisfies(process.version, '>= 6.11.5')) {
-  console.error('Node.js v6.11.x or greater is required to run the Emulator!');
+  console.error('Node.js v6.11.5 or greater is required to run the Emulator!');
   process.exit(1);
 }
 


### PR DESCRIPTION
Replacing the x with the specific version of node required. Otherwise, v6.11.1 would throw an error but that would not be clear from the error message.

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
