### PR TITLE
Handle missing logfiles correctly

### DIFF
--- a/src/emulator/logs.js
+++ b/src/emulator/logs.js
@@ -32,9 +32,8 @@ function readLogLines (filePath, linesToRead, output) {
   stream.on('error', (err) => {
     if (err.code === 'ENOENT') {
       output('');
-      return;
     }
-  })
+  });
 
   const rl = readline.createInterface({
     input: stream,

--- a/src/emulator/logs.js
+++ b/src/emulator/logs.js
@@ -20,37 +20,36 @@ const path = require('path');
 const readline = require('readline');
 
 function readLogLines (filePath, linesToRead, output) {
-  try {
-    const parts = path.parse(filePath);
-    const files = fs
-      .readdirSync(parts.dir)
-      .filter((file) => file && file.includes(parts.name));
-    files.sort();
+  const parts = path.parse(filePath);
+  const files = fs
+    .readdirSync(parts.dir)
+    .filter((file) => file && file.includes(parts.name));
+  files.sort();
 
-    // Here, we naively select the newest log file, even if the user wants to
-    // display more lines than are available in the newest log file.
-    const rl = readline.createInterface({
-      input: fs.createReadStream(path.join(parts.dir, files[files.length - 1])),
-      terminal: false
-    });
-    const lines = [];
-    rl
-      .on('line', (line) => {
-        lines.push(line);
-      })
-      .on('close', () => {
-        lines
-          .slice(lines.length - linesToRead)
-          .forEach((line) => output(`${line}\n`));
-      });
-  } catch (err) {
+  // Here, we naively select the newest log file, even if the user wants to
+  // display more lines than are available in the newest log file.
+  const stream = fs.createReadStream(path.join(parts.dir, files[files.length - 1] || ''));
+  stream.on('error', (err) => {
     if (err.code === 'ENOENT') {
       output('');
       return;
     }
+  })
 
-    throw err;
-  }
+  const rl = readline.createInterface({
+    input: stream,
+    terminal: false
+  });
+  const lines = [];
+  rl
+    .on('line', (line) => {
+      lines.push(line);
+    })
+    .on('close', () => {
+      lines
+        .slice(lines.length - linesToRead)
+        .forEach((line) => output(`${line}\n`));
+    });
 }
 
 module.exports = {


### PR DESCRIPTION
As title - see [relevant SO question](https://stackoverflow.com/questions/17136536/is-enoent-from-fs-createreadstream-uncatchable).

(Also, there are some test failures - but I suspect they are unrelated to this PR.)