### PR TITLE
Improve wording of semver warning

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -22,13 +22,13 @@ require('colors');
  */
 const semver = require('semver');
 if (!semver.satisfies(process.version, '>= 6.11.5')) {
-  console.error('You are required to use Node.js versions between v6.11.5 and v6.14.1 inclusive.');
+  console.error('You are required to use Node.js versions between v6.11.5 and v6.14.0 inclusive.');
   process.exit(1);
 }
 
 if (semver.satisfies(process.version, '>= 7.0.0')) {
   console.log(`Warning: You're using Node.js ${process.version} but the Cloud Functions Emulator only supports versions' +
-    'between v6.11.5 and v6.14.1 inclusive.`);
+    'between v6.11.5 and v6.14.0 inclusive.`);
 }
 
 /**

--- a/bin/functions
+++ b/bin/functions
@@ -22,12 +22,13 @@ require('colors');
  */
 const semver = require('semver');
 if (!semver.satisfies(process.version, '>= 6.11.5')) {
-  console.error('Node.js v6.11.5 or greater is required to run the Emulator!');
+  console.error('You are required to use Node.js versions between v6.11.5 and v6.14.1 inclusive.');
   process.exit(1);
 }
 
 if (semver.satisfies(process.version, '>= 7.0.0')) {
-  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions only supports v6.11.5.`);
+  console.log(`Warning: You're using Node.js ${process.version} but the Cloud Functions Emulator only supports versions' +
+    'between v6.11.5 and v6.14.1 inclusive.`);
 }
 
 /**


### PR DESCRIPTION
The current wording could be confusing. For example:
- Customer has Node v5, sees message that "v6.11.5 or greater is required to run the Emulator"
- They upgrade their Node version to the latest, thinking that the more updated the better. 
- They then get another error message that Google Cloud Functions only supports v6.11.5

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
