### PR TITLE
Allow emulator work work on node version ^6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": "~6"
+    "node": "^6"
   },
   "repository": "GoogleCloudPlatform/cloud-functions-emulator",
   "main": "./bin/emulator",


### PR DESCRIPTION
Fixes #267 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

The restriction on the node version seems unnecessary. This causes issues with the firebase tool packages which relies on this.