### PR TITLE
Add support for Firebase Remote Config events

### DIFF
--- a/src/cli/commands/deploy.js
+++ b/src/cli/commands/deploy.js
@@ -94,14 +94,14 @@ exports.builder = (yargs) => {
         type: 'string'
       },
       'trigger-event': {
-        choices: ['topic.publish', 'object.change', 'user.create', 'user.delete', 'ref.write', 'ref.create', 'ref.update', 'ref.delete', 'event.log', undefined],
+        choices: ['topic.publish', 'object.change', 'user.create', 'user.delete', 'ref.write', 'ref.create', 'ref.update', 'ref.delete', 'event.log', 'update', undefined],
         description: `${'LEGACY'.yellow}: Specifies which action should trigger the function. If omitted, a default EVENT_TYPE for --trigger-provider will be used if it is available. For a list of acceptable values, call functions event_types list. EVENT_TYPE must be one of: topic.publish, object.change, user.create, user.delete, ref.write, ref.create, ref.update, ref.delete, event.log.`,
         requiresArg: true,
         type: 'string',
         required: false
       },
       'trigger-provider': {
-        choices: ['cloud.pubsub', 'cloud.storage', 'google.firebase.auth', 'google.firebase.database', 'google.firebase.analytics', undefined],
+        choices: ['cloud.pubsub', 'cloud.storage', 'google.firebase.auth', 'google.firebase.database', 'google.firebase.analytics', 'google.firebase.remoteconfig', undefined],
         description: `${'LEGACY'.yellow}: Trigger this function in response to an event in another service. For a list of acceptable values, call gcloud functions event-types list. PROVIDER must be one of: cloud.pubsub, cloud.storage, google.firebase.auth, google.firebase.database, google.firebase.analytics`,
         requiresArg: true,
         type: 'string',

--- a/src/cli/controller.js
+++ b/src/cli/controller.js
@@ -337,7 +337,10 @@ class Controller {
             }
           } else if (opts.triggerProvider === 'google.firebase.analytics') {
             opts.triggerEvent || (opts.triggerEvent = 'event.log');
+          } else if (opts.triggerProvider === 'google.firebase.remoteconfig') {
+            opts.triggerEvent || (opts.triggerEvent = 'update');
           }
+
           cloudfunction.eventTrigger = {
             eventType: `${opts.triggerProvider}.${opts.triggerEvent}`
           };


### PR DESCRIPTION
Add support for new event type: Firebase Remote Config

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

The tests fail with the message "error @google-cloud/nodejs-repo-tools@2.3.5: The engine "node" is incompatible with this module. Expected version ">=8.0.0"." But it seems like the same thing is also happening on Master. 

I don't believe any documentation needs to be updated,since the wiki does not directly mention event types, but please let me know if I need to actually update anything. 