### PR TITLE
Update engines requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=6, <10"
+    "node": ">=6 <10"
   },
   "repository": "GoogleCloudPlatform/cloud-functions-emulator",
   "main": "./bin/emulator",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": "~6"
+    "node": ">=6, <10"
   },
   "repository": "GoogleCloudPlatform/cloud-functions-emulator",
   "main": "./bin/emulator",


### PR DESCRIPTION
Updating the engines field of package.json, so users can install the package while running Node 8, and with the `engine-strict` flag on. 

I changed the version to be above or equal to 6, and under Node 10. The rationale is that Node 10 does not work well with the emulator (see https://github.com/GoogleCloudPlatform/cloud-functions-emulator/issues/205)

- [ ] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
