### PR TITLE
fix: add missing cli-table3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ajv": "^6.5.2",
     "body-parser": "^1.18.3",
     "chokidar": "^2.0.4",
-    "cli-table2": "0.2.0",
+    "cli-table3": "^0.5.1",
     "colors": "^1.3.1",
     "configstore": "^4.0.0",
     "express": "^4.16.3",


### PR DESCRIPTION
Hey there 👋

I've tried using latest alpha version and noticed there's missing dep on `cli-table3`. I believe it went missing after merge conflict resolution as part of #216. Cheers ✌️