### PR TITLE
Fix: Fix lint

### DIFF
--- a/test/unit/service/rest-service.test.js
+++ b/test/unit/service/rest-service.test.js
@@ -97,7 +97,7 @@ describe('unit/service/rest-service', () => {
 
       nock('https://faked.com')
         .post('/fake-project/us-central1/test-function', {
-          auth: {admin: true}
+          auth: { admin: true }
         })
         .reply(200);
 
@@ -124,7 +124,7 @@ describe('unit/service/rest-service', () => {
 
       nock('https://faked.com')
         .post('/fake-project/us-central1/test-function', {
-          auth: {admin: false},
+          auth: { admin: false },
           resource: 'custom.resource'
         })
         .reply(200);
@@ -132,7 +132,7 @@ describe('unit/service/rest-service', () => {
       request(service.server)
         .post('/v1/projects/fake-project/locations/us-central1/functions/test-function:call')
         .send({
-          auth: {admin: false},
+          auth: { admin: false },
           resource: 'custom.resource'
         })
         .expect(200, done);


### PR DESCRIPTION
Fixes `yarn lint` issues.

```sh
yarn run lint
yarn run v1.12.3
$ semistandard
semistandard: Semicolons For All! (https://github.com/Flet/semistandard)
semistandard: Run `semistandard --fix` to automatically fix some problems.
  /github/GoogleCloudPlatform/cloud-functions-emulator/test/unit/service/rest-service.test.js:127:17: A space is required after '{'.
  /github/GoogleCloudPlatform/cloud-functions-emulator/test/unit/service/rest-service.test.js:127:30: A space is required before '}'.
  /github/GoogleCloudPlatform/cloud-functions-emulator/test/unit/service/rest-service.test.js:135:17: A space is required after '{'.
  /github/GoogleCloudPlatform/cloud-functions-emulator/test/unit/service/rest-service.test.js:135:30: A space is required before '}'.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```