### PR TITLE
doc: update runtime version error

### DIFF
--- a/bin/emulator
+++ b/bin/emulator
@@ -23,7 +23,7 @@ if (!semver.satisfies(process.version, '>= 6.11.5')) {
 }
 
 if (semver.satisfies(process.version, '>= 7.0.0')) {
-  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions only supports v6.11.5.`);
+  console.log(`Warning: You're using Node.js ${process.version} but Google Cloud Functions emulator only supports v6.x.`);
 }
 
 exports.emulator = require('../src/emulator');


### PR DESCRIPTION
The current error has left some customers thinking that we only support
6.x in google cloud. This update makes it explicit that only the
emulator itself has this limitation


Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)